### PR TITLE
build pod as framework

### DIFF
--- a/CTFuzzySearch.podspec
+++ b/CTFuzzySearch.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name           = 'CTFuzzySearch'
-  s.version        = '1.0.0'
+  s.version        = '1.0.1'
   s.summary        = "CTFuzzySearch is a lightweight framework for fast and fuzzy string searching."
   s.homepage       = "https://github.com/cwimberger/ctfuzzysearch"
   s.author         = { 'Christoph Wimberger' => 'christoph@wimberger.org' }

--- a/source/CTFuzzyIndex.m
+++ b/source/CTFuzzyIndex.m
@@ -5,7 +5,6 @@
 #import "CTDFA.h"
 #import "CTNFA.h"
 #import "CTIntTuple.h"
-#import "CTFuzzyMatch.h"
 #import "CTFuzzyMatch-Private.h"
 
 @implementation CTFuzzyIndex

--- a/source/CTFuzzyMatch-Private.h
+++ b/source/CTFuzzyMatch-Private.h
@@ -1,6 +1,7 @@
 //  Copyright (c) 2014 Christoph Wimberger. All rights reserved.
 
 #import <Foundation/Foundation.h>
+#import "CTFuzzyMatch.h"
 
 @interface CTFuzzyMatch (private)
 


### PR DESCRIPTION
If the podfile is using the option "use_frameworks!", CTFuzzysearch is no compiling due to a missing header import. This PR adds CTFuzzyMatch.h it's private extension. 

BTW, thanks for creating this library. :+1: 
